### PR TITLE
Bug Fix of Issue 46

### DIFF
--- a/binn/explainer.py
+++ b/binn/explainer.py
@@ -60,6 +60,9 @@ class BINNExplainer:
         ):
             sv = np.asarray(sv)
             sv = abs(sv)
+            # we need sv to be of shape (n_classes, n_samples, n_features)
+            if sv.shape[1] != len(test_data):
+                sv = np.transpose(sv, (2, 0, 1)) 
             sv_mean = np.mean(sv, axis=1)
 
             for feature in range(sv_mean.shape[-1]):
@@ -271,8 +274,8 @@ class BINNExplainer:
                 if layer_index == wanted_layer:
                     explainer = shap.DeepExplainer((self.model, layer), background_data)
                     shap_values = explainer.shap_values(test_data)
-                    shap_dict["features"] += self.model.layer_names[wanted_layer]
-                    shap_dict["shap_values"] += shap_values
+                    shap_dict["features"].append(self.model.layer_names[wanted_layer])
+                    shap_dict["shap_values"].append(shap_values)
                     return shap_dict
                 layer_index += 1
                 intermediate_data = layer(intermediate_data)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ requirements = [
     "pandas",
     "torch",
     "lightning",
-    "shap<=0.44.1",
+    "shap",
     "matplotlib",
     "plotly",
     "nbformat>=4.2.0",

--- a/tests/test_explainer.py
+++ b/tests/test_explainer.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 
 @pytest.fixture
-def binn_explainer(return_input=False):
+def binn_explainer():
     input_data = pd.DataFrame({"Protein": ["a", "b", "c"]})
     pathways = pd.DataFrame(
         {"source": ["A", "B", "C"], "target": ["path1", "path1", "path2"]}

--- a/tests/test_explainer.py
+++ b/tests/test_explainer.py
@@ -59,8 +59,6 @@ def test_binn_explainer_explain_output(binn_explainer: BINNExplainer):
             for j in cm.columns.tolist():
                 if cm.loc[i, j] == 1:
                     theoretical_unique_pairs.append((i, j))
-                    
-    print(unique_pairs)
          
     assert set(unique_pairs) == set(theoretical_unique_pairs)
 

--- a/tests/test_explainer.py
+++ b/tests/test_explainer.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 
 @pytest.fixture
-def binn_explainer():
+def binn_explainer(return_input=False):
     input_data = pd.DataFrame({"Protein": ["a", "b", "c"]})
     pathways = pd.DataFrame(
         {"source": ["A", "B", "C"], "target": ["path1", "path1", "path2"]}
@@ -20,7 +20,6 @@ def binn_explainer():
 
 def test_binn_explainer_init(binn_explainer: BINNExplainer):
     assert isinstance(binn_explainer.model, BINN)
-
 
 def test_binn_explainer_update_model(binn_explainer: BINNExplainer):
     input_data = pd.DataFrame({"Protein": ["a", "b", "c"]})
@@ -43,6 +42,26 @@ def test_binn_explainer_explain(binn_explainer: BINNExplainer):
     result = binn_explainer.explain(test_data, background_data)
     assert isinstance(result, pd.DataFrame)
     assert len(result) > 0
+    
+def test_binn_explainer_explain_output(binn_explainer: BINNExplainer):
+    test_data = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.float32)
+    background_data = torch.tensor([[7, 8, 9], [10, 11, 12]], dtype=torch.float32)
+
+    result = binn_explainer.explain(test_data, background_data)
+
+    unique_pairs = result[["source name", "target name"]].drop_duplicates()
+    unique_pairs = [(s, t) for s, t in zip(unique_pairs["source name"], unique_pairs["target name"])]
+    
+    theoretical_unique_pairs = []
+    for cm in binn_explainer.model.connectivity_matrices:
+        for i in cm.index.tolist():
+            for j in cm.columns.tolist():
+                if cm.loc[i, j] == 1:
+                    theoretical_unique_pairs.append((i, j))
+                    
+    print(unique_pairs)
+         
+    assert set(unique_pairs) == set(theoretical_unique_pairs)
 
 
 def test_binn_explainer_explain_input(binn_explainer: BINNExplainer):

--- a/tests/test_explainer.py
+++ b/tests/test_explainer.py
@@ -20,6 +20,7 @@ def binn_explainer():
 
 def test_binn_explainer_init(binn_explainer: BINNExplainer):
     assert isinstance(binn_explainer.model, BINN)
+    
 
 def test_binn_explainer_update_model(binn_explainer: BINNExplainer):
     input_data = pd.DataFrame({"Protein": ["a", "b", "c"]})


### PR DESCRIPTION
Fixes Issue #46 

The bug occurs in BINNExplainer.explain, where the ship value matrix has a different shape in python 3.11.
Previously, it was shape (n_classes, n_samples, n_features), not it is (n_samples, n_features, n_classes).

To fix the bug, I check whether the length of the second dimension of the shap value matrix is equal to the number of samples in the test_data. 

I made a merge request which implements the fix, and adds a test that checks if each unique pair of (source, target) gets a shap value in the output DataFrame of BINNExplainer.explain().