### PR TITLE
Improve mapping speed with set usage

### DIFF
--- a/binn/model/pathway_network.py
+++ b/binn/model/pathway_network.py
@@ -1,6 +1,6 @@
 import itertools
 import re
-from typing import Set, Tuple
+from typing import Set, List, Tuple
 import networkx as nx
 import numpy as np
 import pandas as pd

--- a/binn/model/pathway_network.py
+++ b/binn/model/pathway_network.py
@@ -1,13 +1,13 @@
 import itertools
 import re
-from typing import List, Tuple
+from typing import Set, Tuple
 import networkx as nx
 import numpy as np
 import pandas as pd
 
 
 def _subset_mapping(
-    input_data: List[str], mapping: List[Tuple[str, str]]
+    input_data: Set[str], mapping: List[Tuple[str, str]]
 ) -> List[Tuple[str, str]]:
     return [m for m in mapping if m[0] in input_data]
 
@@ -162,7 +162,7 @@ class PathwayNetwork:
         self.mapping = mapping 
 
         # Subset the mapping to keep only entries related to input_data
-        self.mapping = _subset_mapping(self.input_data, self.mapping)
+        self.mapping = _subset_mapping(set(self.input_data), self.mapping)
 
         # Subset the pathways by the indices derived from the mapping
         self.pathways = _subset_pathways_on_idx(self.pathways, self.mapping)


### PR DESCRIPTION
This pull request makes modifications to the `binn/model/pathway_network.py` file to enhance code performance and maintainability.

#### Changes:
1. **Import Statements:**
   - Added `Set` to the list of imports from the `typing` module.
   ```python
   from typing import Set, List, Tuple
   ```

2. **_subset_mapping Function:**
   - Changed the type of `input_data` from `List[str]` to `Set[str]`.
   ```python
   input_data: Set[str], mapping: List[Tuple[str, str]]
   ```

3. **__init__ Method:**
   - Converted `input_data` to a set before passing it to `_subset_mapping`.
   ```python
   self.mapping = _subset_mapping(set(self.input_data), self.mapping)
   ```

#### Benefits:
- Faster membership checks with sets.
- Eliminates duplicates in `input_data` for reliable mappings.