### PR TITLE
Optimize get_layers

### DIFF
--- a/binn/model/pathway_network.py
+++ b/binn/model/pathway_network.py
@@ -211,15 +211,18 @@ class PathwayNetwork:
 
         # Create a final mapping of terminal pathways -> input(s)
         mapping_df = self.mapping
+        grouped_inputs = (
+            mapping_df.groupby("connections")["input"]
+            .apply(lambda x: x.unique().tolist())
+            .to_dict()
+        )
+        
         terminal_mapping = {}
         missing_pathways = []
         for term_node in terminal_nodes:
             pathway_name = re.sub(r"_copy.*", "", term_node)
-            inputs_for_pathway = (
-                mapping_df.loc[mapping_df["connections"] == pathway_name, "input"]
-                .unique()
-                .tolist()
-            )
+
+            inputs_for_pathway = grouped_inputs.get(pathway_name, [])
 
             if not inputs_for_pathway:
                 missing_pathways.append(pathway_name)


### PR DESCRIPTION
This pull request optimizes the `get_layers` method in the `binn/model/pathway_network.py` file to improve performance and readability.

#### Changes:
1. **Grouping Inputs by Connections:**
   - The inputs are now grouped by connections using the `groupby` method, and the unique inputs are collected into a dictionary. This is done once before the loop to prevent redundancy and improve performance.
   ```python
   grouped_inputs = (
       mapping_df.groupby("connections")["input"]
       .apply(lambda x: x.unique().tolist())
       .to_dict()
   )
   ```

2. **Updating Terminal Pathway Inputs:**
   - The inputs for each terminal pathway are now retrieved from the `grouped_inputs` dictionary instead of using the `loc` method.
   ```python
   inputs_for_pathway = grouped_inputs.get(pathway_name, [])
   ```

#### Benefits:
- Grouping the inputs once and using a dictionary lookup reduces the number of repeated operations, enhancing the overall efficiency of the `get_layers` method.
- The code is more concise and easier to understand, making it simpler for future maintenance and modifications.