### PR TITLE
Improve speed in _get_map_from_layer

### DIFF
--- a/binn/model/pathway_network.py
+++ b/binn/model/pathway_network.py
@@ -68,13 +68,30 @@ def _get_map_from_layer(layer_dict: dict) -> pd.DataFrame:
     (rows = pathways, columns = inputs).
     """
     pathways = list(layer_dict.keys())
-    all_inputs = list(itertools.chain.from_iterable(layer_dict.values()))
-    unique_inputs = list(np.unique(all_inputs))
 
-    df = pd.DataFrame(index=pathways, columns=unique_inputs)
-    for pathway, inputs in layer_dict.items():
-        df.loc[pathway, inputs] = 1
-    df = df.infer_objects(copy=False).fillna(0)
+    unique_inputs = set()
+    for inputs_list in layer_dict.values():
+        unique_inputs.update(inputs_list)
+
+    unique_inputs = list(unique_inputs)
+
+    # Create an empty matrix of 0's
+    mat = np.zeros((len(pathways), len(unique_inputs)), dtype=int)
+
+    # Map pathway -> row index
+    pathway_to_idx = {p: i for i, p in enumerate(pathways)}
+    # Map input -> column index
+    input_to_idx = {inp: j for j, inp in enumerate(unique_inputs)}
+
+    # Fill the matrix
+    for p, inputs_list in layer_dict.items():
+        row_idx = pathway_to_idx[p]
+        for inp in inputs_list:
+            col_idx = input_to_idx[inp]
+            mat[row_idx, col_idx] = 1
+
+    # Build DataFrame
+    df = pd.DataFrame(mat, index=pathways, columns=unique_inputs)
 
     return df.T
 


### PR DESCRIPTION
This pull request improves the performance of the `_get_map_from_layer` function in the `binn/model/pathway_network.py` file.

#### Changes:
1. **Refactor Input Collection:**
   - Changed from using `itertools.chain.from_iterable` and `np.unique` to using a `set` to collect unique inputs.
   ```python
   unique_inputs = set()
   for inputs_list in layer_dict.values():
       unique_inputs.update(inputs_list)
   unique_inputs = list(unique_inputs)
   ```

2. **Matrix Initialization and Population:**
   - Initialized a zero matrix and used dictionaries to map pathways and inputs to indices.
   - Populated the matrix based on these mappings.
   ```python
   mat = np.zeros((len(pathways), len(unique_inputs)), dtype=int)
   pathway_to_idx = {p: i for i, p in enumerate(pathways)}
   input_to_idx = {inp: j for j, inp in enumerate(unique_inputs)}
   for p, inputs_list in layer_dict.items():
       row_idx = pathway_to_idx[p]
       for inp in inputs_list:
           col_idx = input_to_idx[inp]
           mat[row_idx, col_idx] = 1
   ```

3. **DataFrame Construction:**
   - Constructed the DataFrame from the populated matrix.
   ```python
   df = pd.DataFrame(mat, index=pathways, columns=unique_inputs)
   ```

#### Benefits:
- The new approach reduces the number of operations needed to collect unique inputs and populate the DataFrame, making the function faster.